### PR TITLE
fix(cupboard): set max-jobs only for the build, not the installer

### DIFF
--- a/.github/workflows/cupboard-publish.yml
+++ b/.github/workflows/cupboard-publish.yml
@@ -87,12 +87,12 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
-          # nixbuild.net realises every derivation, so the runner builds
-          # nothing locally. Reads come from the public caches and from the
-          # default cupboard cache, so promoted builds make later runs
-          # incremental.
+          # Read from the public caches and the default cupboard cache, so
+          # promoted builds make later runs incremental. The build step forces
+          # every derivation onto nixbuild.net with `--max-jobs 0`; it is not set
+          # here because the installer builds a profile locally while setting Nix
+          # up, which `max-jobs = 0` would block.
           extra-conf: |
-            max-jobs = 0
             extra-substituters = https://cupboard.supply/t/laney
             extra-trusted-public-keys = cupboard-1:rupCzv0DJn5yLpuqAZl9IrzjadNvD2d+BQxIqNoFZKQ=
 
@@ -112,7 +112,7 @@ jobs:
           : > "$paths"
           for name in $names; do
             echo "::group::packages.${SYSTEM}.${name}"
-            nix build ".#packages.${SYSTEM}.${name}" --no-link --print-out-paths >> "$paths"
+            nix build ".#packages.${SYSTEM}.${name}" --max-jobs 0 --no-link --print-out-paths >> "$paths"
             echo '::endgroup::'
           done
           {


### PR DESCRIPTION
The publish run failed before building anything: the nix-installer step aborted in `setup_default_profile`, which builds an empty user environment locally while installing Nix. The installer config carried `max-jobs = 0`, so that local build was refused and the install errored.

`max-jobs = 0` belongs only on the build, where it forces every derivation onto the nixbuild.net remote builder. Drop it from the installer's extra-conf and pass `--max-jobs 0` to `nix build` instead. The flag is used rather than NIX_CONFIG so it cannot clobber the `builders` setting nixbuild-action installs.
