### PR TITLE
ci: fix flake-update secrets access, run daily, and describe the relock

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -15,7 +15,7 @@ name: flake update
 
 on:
   schedule:
-    - cron: "0 5 * * 1" # Mondays, 05:00 UTC, alongside the weekly lockfile maintenance
+    - cron: "0 5 * * *" # Daily, 05:00 UTC
   workflow_dispatch:
 
 permissions: {}
@@ -37,6 +37,21 @@ jobs:
           persist-credentials: false
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      # The `secrets` input lives in the private dotfiles-secrets repo, reachable
+      # only over SSH. Configure the read-only deploy key so `nix flake update`
+      # can relock it, the same key the cupboard workflow uses to build the host
+      # and home closures.
+      - name: Set up secrets access
+        env:
+          DEPLOY_KEY: ${{ secrets.SECRETS_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+
+          key="${RUNNER_TEMP}/secrets_deploy_key"
+          install -m 600 /dev/null "${key}"
+          printf '%s\n' "${DEPLOY_KEY}" > "${key}"
+          echo "GIT_SSH_COMMAND=ssh -i ${key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=${RUNNER_TEMP}/known_hosts" >> "${GITHUB_ENV}"
 
       - name: Relock flake inputs
         env:

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -77,25 +77,48 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git switch -C flake-update
-          git commit -am "chore(flake): update inputs"
-          git push --force origin HEAD:refs/heads/flake-update
+          summary="$(./scripts/flake-lock-summary.bash <(git show HEAD:flake.lock) flake.lock)"
 
-          if gh pr view flake-update --json state >/dev/null 2>&1; then
-            echo "Existing pull request updated by the push."
+          branch="flake-update/$(date -u +%Y-%m-%d)"
+          export branch
+
+          # Keep a single relock in flight: close any earlier flake-update PRs and
+          # delete their branches, then sweep up any branches left without a PR.
+          gh pr list --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("flake-update/")) | select(.headRefName != env.branch) | .number' \
+            | while read -r number; do
+                gh pr close "${number}" --delete-branch
+              done
+
+          git ls-remote --heads origin "refs/heads/flake-update/*" \
+            | sed 's#.*refs/heads/##' \
+            | while read -r stale; do
+                [ "${stale}" = "${branch}" ] && continue
+                git push origin --delete "${stale}"
+              done
+
+          git switch -C "${branch}"
+          git commit -am "chore(flake): update inputs"
+          git push --force origin "HEAD:refs/heads/${branch}"
+
+          body="$(printf '%s\n' \
+            "Automated relock of the flake inputs from the scheduled \`flake-update\` workflow: the hermes-agent release bump followed by \`nix flake update\`." \
+            "" \
+            "Updated inputs:" \
+            "" \
+            "${summary}" \
+            "" \
+            "Merging this publishes the rebuilt closure to the cupboard cache through the \`cupboard\` workflow's push-to-main build.")"
+
+          if gh pr view "${branch}" --json state >/dev/null 2>&1; then
+            gh pr edit "${branch}" --body "${body}"
+            echo "Existing pull request updated."
             exit 0
           fi
 
-          body="$(printf '%s\n' \
-            "Automated relock of the flake inputs from the scheduled \`flake-update\`" \
-            "workflow: the hermes-agent release bump followed by \`nix flake update\`." \
-            "" \
-            "Merging this publishes the rebuilt closure to the cupboard cache through" \
-            "the \`cupboard\` workflow's push-to-main build.")"
-
           gh pr create \
             --base main \
-            --head flake-update \
+            --head "${branch}" \
             --title "chore(flake): update inputs" \
             --label dependencies \
-            --body "$body"
+            --body "${body}"

--- a/scripts/flake-lock-summary.bash
+++ b/scripts/flake-lock-summary.bash
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Summarise the top-level input changes between two flake.lock files as a
+# Markdown list, for the body of the automated flake-update pull request.
+#
+# Usage: flake-lock-summary.bash <before.json> <after.json>
+
+set -euo pipefail
+
+before="${1:?usage: flake-lock-summary.bash <before> <after>}"
+after="${2:?usage: flake-lock-summary.bash <before> <after>}"
+
+jq -rn --slurpfile before "${before}" --slurpfile after "${after}" '
+  def version($lock; $name):
+    $lock.nodes.root.inputs[$name] as $id
+    | if $id == null then null
+      else $lock.nodes[$id] as $node
+        | { ref: ($node.original.ref // $node.locked.ref),
+            rev: ($node.locked.rev // $node.locked.narHash) }
+      end;
+
+  ($before[0]) as $b
+  | ($after[0]) as $a
+  | (($b.nodes.root.inputs // {}) + ($a.nodes.root.inputs // {}) | keys)
+  | map(
+      . as $name
+      | version($b; $name) as $old
+      | version($a; $name) as $new
+      | select($old != $new)
+      | if $old == null then "- `\($name)`: added"
+        elif $new == null then "- `\($name)`: removed"
+        elif ($old.ref // "") != ($new.ref // "")
+          then "- `\($name)`: `\($old.ref)` → `\($new.ref)`"
+        else "- `\($name)`: `\($old.rev[0:7])` → `\($new.rev[0:7])`"
+        end)
+  | .[]
+'


### PR DESCRIPTION
## Problem

The scheduled `flake update` job ([failing run](https://github.com/iainlane/dotfiles/actions/runs/28323202291/job/83908669695)) ran a bare `nix flake update`, relocking every input including `secrets` (the private `dotfiles-secrets` repo, reachable only over SSH). The runner had no key, so it failed with `Permission denied (publickey)` and never opened its PR.

Separately, the PR it opens always carried the same static, hard-wrapped body, force-pushed to a single `flake-update` branch, telling a reviewer nothing about what actually moved.

## Changes

- Reuse the read-only deploy key the cupboard workflow already uses (`SECRETS_DEPLOY_KEY`): write it out and set `GIT_SSH_COMMAND` before relocking, so the full `nix flake update` can fetch the secrets input.
- Move the schedule from weekly (Mondays) to daily, both at 05:00 UTC.
- Open each run's PR from a dated `flake-update/<date>` branch and keep a single relock in flight: close any earlier flake-update PRs, delete their branches, and sweep up any branches left without one.
- Add `scripts/flake-lock-summary.bash`, which diffs the committed `flake.lock` against the relocked one and lists each changed input (moved tag or short revision). The PR body now says exactly which updates it contains, and its prose is no longer hard-wrapped.

## Verification

The secrets-access fix was confirmed by a `workflow_dispatch` run against this branch: the previously-failing "Relock flake inputs" step passed and the job opened its PR. The new body construction was verified locally against a synthetic lock diff:

> Updated inputs:
>
> - `hermes-agent`: `v2026.6.19` → `v2026.7.1`
> - `nixpkgs`: `3e41b24` → `deadbee`

The legacy `flake-update` branch and its auto-PR (#142) were closed as a one-off, since the reworked workflow manages only the `flake-update/*` namespace.