### PR TITLE
ci(cupboard): enlarge the runner store with nothing-but-nix

### DIFF
--- a/.github/workflows/cupboard-publish.yml
+++ b/.github/workflows/cupboard-publish.yml
@@ -100,6 +100,17 @@ jobs:
             echo "root_prefix=${root_prefix}"
           } >> "$GITHUB_OUTPUT"
 
+      # The remote builds run on nixbuild.net, but every realised path is copied
+      # back into this runner's local store. A full sweep of the host and home
+      # closures across both systems outgrows the runner's stock ~20GB on /,
+      # truncating a NAR mid-copy ("unexpected end-of-file"). Reclaim space into
+      # /nix before Nix is installed. The holster protocol leaves the runner's
+      # own tooling (node, jq, tar) intact for the cupboard actions below.
+      # renovate: datasource=github-releases depName=wimpysworld/nothing-but-nix
+      - uses: wimpysworld/nothing-but-nix@687c797a730352432950c707ab493fcc951818d7 # v10
+        with:
+          hatchet-protocol: holster
+
       - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
         with:
           # Single-user Nix: the build process itself evaluates and connects to


### PR DESCRIPTION
## Problem

The aarch64 publish job ([run 28356811169](https://github.com/iainlane/dotfiles/actions/runs/28356811169/job/84001660391)) failed building `homeConfigurations."laney@ancaster".activationPackage`:

```
error: unexpected end-of-file
error: Cannot build '/nix/store/...-hm_gitconfig.drv'.
```

The builds run remotely on nixbuild.net (`nix build --max-jobs 0`), but every realised path is copied back into the runner's local Nix store. A full sweep of the host and home closures across both systems outgrows the stock ~20GB on a GitHub runner's root filesystem. When the store fills, an in-flight NAR import is truncated, which surfaces as that EOF rather than an explicit out-of-space error.

The job doesn't currently fail the workflow (the build step downgrades per-closure failures to a `::warning::`), so the visible effect is that ancaster's closure silently never lands in the cupboard cache.

## Fix

Run [`wimpysworld/nothing-but-nix`](https://github.com/wimpysworld/nothing-but-nix) before `nix-quick-install-action`, so the store has room before any path is copied.

- **`holster` protocol** (~65GB into `/nix`): claims space from `/mnt` while leaving the runner's own tooling (node, jq, tar) intact, which the cupboard attest and push steps still need.
- **Pinned by commit** with a `# renovate:` comment, matching how the rest of the workflow pins its actions.

If 65GB gets tight as more hosts are added, `carve` (~85GB, still keeps tooling) is the next step before the more destructive protocols.